### PR TITLE
test unskipped for multiple line tags count

### DIFF
--- a/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
+++ b/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
@@ -330,8 +330,7 @@ describe('CollapsibleTagsinput', () => {
       })
 
 
-      // TODO: Will fix this in other MR
-      xit('should update count when tags are added ' +
+      it('should update count when tags are added ' +
          'and input is on multiple lines', async () => {
         await page.click('#add-tag')
         await page.click('#add-tag')


### PR DESCRIPTION
## Description
The test Spec `should update count when tags are added and input is on multiple lines` was skipped even though it is passing locally.

## Context
Test passes while running locally

## How Has This Been Tested?
locally

## Types of changes
e2e test Only
