### PR TITLE
Revert "Merge pull request #16 from Talank/unskip-tag-count-test"

### DIFF
--- a/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
+++ b/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
@@ -330,7 +330,8 @@ describe('CollapsibleTagsinput', () => {
       })
 
 
-      it('should update count when tags are added ' +
+      // TODO: Will fix this in other MR
+      xit('should update count when tags are added ' +
          'and input is on multiple lines', async () => {
         await page.click('#add-tag')
         await page.click('#add-tag')


### PR DESCRIPTION
This reverts commit bd9829a75b2f37a845f7f6d092b2159f3dd2f19b, reversing
changes made to deacbedc63362fc2eb0375b20731817b54c0d2bd.

The spec still fails, randomly. This will have to be dealt with later. 

https://github.com/avocode/avocode-email-tagsinput/pull/20#issuecomment-617079063