### PR TITLE
Fix/include external css in dist builds

### DIFF
--- a/packages/avocode-email-tagsinput/styles/index.css
+++ b/packages/avocode-email-tagsinput/styles/index.css
@@ -1,3 +1,4 @@
+@import '~@avocode/better-react-tagsinput/dist/main.css';
 @import './avocode-email-tagsinput.css';
 @import './counter.css';
 @import './email-tag.css';

--- a/packages/styled-avocode-email-tagsinput/package.json
+++ b/packages/styled-avocode-email-tagsinput/package.json
@@ -39,7 +39,8 @@
     "flow:libdef": "flow-copy-source -v lib/ dist/",
     "flow:libdef:watch": "flow-copy-source -vw lib/ dist/",
     "copy-public-flow-types": "cp lib/types.js dist/",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "profile": "webpack --mode=development --profile --json > stats.json"
   },
   "bugs": {
     "url": "https://github.com/avocode/avocode-email-tagsinput/issues"

--- a/packages/styled-avocode-email-tagsinput/styles/index.css
+++ b/packages/styled-avocode-email-tagsinput/styles/index.css
@@ -1,3 +1,3 @@
-@import '../node_modules/@avocode/avocode-email-tagsinput/dist/main.css';
+@import '~@avocode/avocode-email-tagsinput/dist/main.css';
 @import './variables.css';
 @import './styled-avocode-email-tagsinput.css';


### PR DESCRIPTION
I was not appending CSS from external dependencies for distribution builds. This PR fixes it so now you don't need to import stylesheets independently from other packages and you can just use root CSS file.