### PR TITLE
Fix/fix font size and dimensions

### DIFF
--- a/packages/playground/components/styled-avocode-email-tagsinput/controlled.js
+++ b/packages/playground/components/styled-avocode-email-tagsinput/controlled.js
@@ -20,6 +20,7 @@ export default class Controlled extends React.PureComponent<{}, State> {
       { value: 'foo@bar.com' },
       { value: 'lorem@ipsum.com', state: 'error' },
       { value: 'dolor@siteamet.com' },
+      { value: 'abcd@xyz.net' },
     ],
     query: '',
   }

--- a/packages/playground/components/styled-avocode-email-tagsinput/errored.js
+++ b/packages/playground/components/styled-avocode-email-tagsinput/errored.js
@@ -1,0 +1,129 @@
+// @flow
+
+import React from 'react'
+import StyledAvocodeEmailTagsInput, { utils } from '@avocode/styled-avocode-email-tagsinput'
+
+import type { Query, Tags } from '@avocode/styled-avocode-email-tagsinput/dist/types'
+
+type State = {
+  query: Query,
+  tags: Tags,
+}
+
+export default class Basic extends React.PureComponent<{}, State> {
+  state = {
+    tags: [
+      { value: 'valid1@email.com' },
+      { value: 'valid2@email.com' },
+      { value: 'valid3@email.com' },
+      { value: 'valid4@email.com' },
+      { value: 'valid5@email.com' },
+      { value: 'valid6@email.com' },
+      { value: 'valid7@email.com' },
+      { value: 'valid8@email.com' },
+      { value: 'valid9@email.com' },
+      { value: 'invalid@email.com', state: 'error' },
+    ],
+    query: '',
+  }
+
+  _handleTagAdd = (text: Query) => {
+    this.setState((prevState) => {
+      return {
+        query: '',
+        tags: [ ...prevState.tags, { value: text } ],
+      }
+    })
+  }
+
+  _handleQueryChange = (query: Query) => {
+    this.setState({ query })
+  }
+
+  _handleTagDelete = (indices: Array<number>) => {
+    this.setState((prevState) => {
+      const nextTags = utils.removeTagsByIndices(
+        prevState.tags,
+        indices
+      )
+
+      return {
+        tags: nextTags,
+      }
+    })
+  }
+
+  render() {
+    const error = new Error('Some error')
+
+    return (
+      <div>
+        <p>
+          If you pass <code>error</code> prop (which can be anything - string, Error object, ...), the input
+          is styled. Additionaly, you can add <code>state: error</code> to your tag to add error styling
+          to specific email(s).
+        </p>
+
+        <div className='theme-container theme-container--light'>
+          <div className='styled-avocode-email-tagsinput-container'>
+            <h2>Light theme</h2>
+            <StyledAvocodeEmailTagsInput
+              error={error}
+              tags={this.state.tags}
+              query={this.state.query}
+              onQueryChangeRequest={this._handleQueryChange}
+              onTagAddRequest={this._handleTagAdd}
+              onTagDeleteRequest={this._handleTagDelete}
+            />
+          </div>
+        </div>
+        <div className='theme-container theme-container--dark'>
+          <div className='styled-avocode-email-tagsinput-container'>
+            <h2 style={{ color: '#fff' }}>Dark theme</h2>
+            <StyledAvocodeEmailTagsInput
+              error={error}
+              theme='dark'
+              tags={this.state.tags}
+              query={this.state.query}
+              onQueryChangeRequest={this._handleQueryChange}
+              onTagAddRequest={this._handleTagAdd}
+              onTagDeleteRequest={this._handleTagDelete}
+            />
+          </div>
+        </div>
+
+        <div className='theme-container theme-container--light'>
+          <div className='styled-avocode-email-tagsinput-container'>
+            <h2>Light theme - non collapsible</h2>
+            <StyledAvocodeEmailTagsInput
+              collapsible={false}
+              error={error}
+              tags={this.state.tags}
+              query={this.state.query}
+              onQueryChangeRequest={this._handleQueryChange}
+              onTagAddRequest={this._handleTagAdd}
+              onTagDeleteRequest={this._handleTagDelete}
+            />
+          </div>
+        </div>
+        <div className='theme-container theme-container--dark'>
+          <div className='styled-avocode-email-tagsinput-container'>
+            <h2 style={{ color: '#fff' }}>Dark theme - non collapsible</h2>
+            <StyledAvocodeEmailTagsInput
+              collapsible={false}
+              error={error}
+              error={error}
+              theme='dark'
+              tags={this.state.tags}
+              query={this.state.query}
+              onQueryChangeRequest={this._handleQueryChange}
+              onTagAddRequest={this._handleTagAdd}
+              onTagDeleteRequest={this._handleTagDelete}
+            />
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+

--- a/packages/playground/components/styled-avocode-email-tagsinput/index.js
+++ b/packages/playground/components/styled-avocode-email-tagsinput/index.js
@@ -6,6 +6,7 @@ import { HashRouter as Router, Route, Link } from 'react-router-dom'
 import Basic from './basic'
 import WithoutCollapsible from './without-collapsible'
 import Controlled from './controlled'
+import Errored from './errored'
 
 type Props = {
   match: {
@@ -26,6 +27,7 @@ export default class StyledAvocodeEmailTagsInputView extends React.PureComponent
               <li className='subnav-item'><Link to={`${url}/basic`}>Basic</Link></li>
               <li className='subnav-item'><Link to={`${url}/without-collapsible`}>Without Collapsible</Link></li>
               <li className='subnav-item'><Link to={`${url}/controlled`}>Controlled</Link></li>
+              <li className='subnav-item'><Link to={`${url}/error`}>Errored</Link></li>
             </ul>
           </nav>
 
@@ -33,6 +35,7 @@ export default class StyledAvocodeEmailTagsInputView extends React.PureComponent
           <Route path={`${url}/basic`} component={Basic} />
           <Route path={`${url}/without-collapsible`} component={WithoutCollapsible} />
           <Route path={`${url}/controlled`} component={Controlled} />
+          <Route path={`${url}/error`} component={Errored} />
         </div>
       </Router>
     )

--- a/packages/styled-avocode-email-tagsinput/README.md
+++ b/packages/styled-avocode-email-tagsinput/README.md
@@ -11,7 +11,7 @@ Also `utils` object is exposed as well, along Flow type definitions.
 
 ```js
 import StyledAvocodeEmailTagsInput from '@avocode/styled-avocode-email-tagsinput'
-@import '@avocode/styled-avocode-email-tagsinput/dist/main.css';
+import '@avocode/styled-avocode-email-tagsinput/dist/main.css';
 
 // [...]
   render() {
@@ -43,3 +43,7 @@ In short you need to pass at least these props:
 ### `theme?: 'light' | 'dark'`
 
 Sets light or dark theme. This prop can be ommited and default theme is set to light. Variables used with each theme are then applied to given CSS classes.
+
+### `error?: any`
+
+Style component for default error state. If the value evaluates as truthy, it's considered that the input has error. Additionally you can add `state` property with value `"error"` to Tag object to mark specific emails as errored as well (for example validation errors).

--- a/packages/styled-avocode-email-tagsinput/lib/styled-avocode-email-tagsinput.js
+++ b/packages/styled-avocode-email-tagsinput/lib/styled-avocode-email-tagsinput.js
@@ -55,6 +55,7 @@ export default class StyledAvocodeEmailTagsinput extends React.PureComponent<Pro
     const { error } = this.props
     const theme = this._getNormalizedTheme(this.props.theme)
     const name = classNames({
+      'styled-avocode-email-tagsinput--error': Boolean(error),
       'styled-avocode-email-tagsinput--light': (theme === 'light' && !error),
       'styled-avocode-email-tagsinput--light--error': (theme === 'light' && error),
       'styled-avocode-email-tagsinput--dark': (theme === 'dark' && !error),

--- a/packages/styled-avocode-email-tagsinput/styles/styled-avocode-email-tagsinput.css
+++ b/packages/styled-avocode-email-tagsinput/styles/styled-avocode-email-tagsinput.css
@@ -2,6 +2,7 @@
 .avocode-email-tagsinput--styled-avocode-email-tagsinput--light,
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--light,
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark {
+  box-sizing: border-box;
   font-family: Open Sans, open-sans, sans-serif;
   font-weight: 600;
   color: var(--text-color-contrast);
@@ -58,7 +59,6 @@
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--light--focused,
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark--focused {
   overflow-y: auto;
-  min-height: 35px;
   height: 100%;
   max-height: 110px;
   align-items: flex-start;
@@ -164,6 +164,13 @@
 .avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--light,
 .avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--dark {
   min-width: var(--counter-min-width);
+}
+
+/* HACK: Unfortunately the node where you type emails (query)
+ *       does not have it's own CSS class */
+.tagsinput > div > div > span:only-child, .tagsinput > div > div > span:last-child {
+  font-size: var(--text-size);
+  margin: 4px 3px;
 }
 
 /* HACK: Firefox has issues with line-height */

--- a/packages/styled-avocode-email-tagsinput/styles/styled-avocode-email-tagsinput.css
+++ b/packages/styled-avocode-email-tagsinput/styles/styled-avocode-email-tagsinput.css
@@ -1,7 +1,9 @@
 .avocode-email-tagsinput--styled-avocode-email-tagsinput--dark,
 .avocode-email-tagsinput--styled-avocode-email-tagsinput--light,
+.avocode-email-tagsinput--styled-avocode-email-tagsinput--error,
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--light,
-.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark {
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark,
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--error {
   box-sizing: border-box;
   font-family: Open Sans, open-sans, sans-serif;
   font-weight: 600;
@@ -13,6 +15,12 @@
 .tagsinput--styled-avocode-email-tagsinput--dark,
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark {
   border-color: transparent;
+}
+
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--error,
+.avocode-email-tagsinput--styled-avocode-email-tagsinput--error,
+.tagsinput--styled-avocode-email-tagsinput--error {
+  border-color: var(--error-color);
 }
 
 .avocode-email-tagsinput--styled-avocode-email-tagsinput--dark,
@@ -28,17 +36,20 @@
 }
 
 .tagsinput--styled-avocode-email-tagsinput--light,
-.tagsinput--styled-avocode-email-tagsinput--dark {
+.tagsinput--styled-avocode-email-tagsinput--dark,
+.tagsinput--styled-avocode-email-tagsinput--error {
   font-size: var(--text-size);
 }
 
 .collapsible-tagsinput--styled-avocode-email-tagsinput--light--collapsed .tagsinput--styled-avocode-email-tagsinput--light,
-.collapsible-tagsinput--styled-avocode-email-tagsinput--dark--collapsed .tagsinput--styled-avocode-email-tagsinput--dark {
+.collapsible-tagsinput--styled-avocode-email-tagsinput--dark--collapsed .tagsinput--styled-avocode-email-tagsinput--dark,
+.collapsible-tagsinput--styled-avocode-email-tagsinput--error .tagsinput--styled-avocode-email-tagsinput--error {
   border-width: 0;
 }
 
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--light,
-.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark {
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark,
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--error {
   font-size: var(--text-size);
   height: 35px;
   overflow: hidden;
@@ -47,7 +58,8 @@
 }
 
 .collapsible-tagsinput--styled-avocode-email-tagsinput--light .tagsinput--styled-avocode-email-tagsinput--light--focused,
-.collapsible-tagsinput--styled-avocode-email-tagsinput--dark .tagsinput--styled-avocode-email-tagsinput--dark--focused {
+.collapsible-tagsinput--styled-avocode-email-tagsinput--dark .tagsinput--styled-avocode-email-tagsinput--dark--focused,
+.collapsible-tagsinput--styled-avocode-email-tagsinput--dark--error .tagsinput--styled-avocode-email-tagsinput--dark--error--focused {
   border-width: 0;
 }
 
@@ -57,7 +69,9 @@
 }
 
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--light--focused,
-.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark--focused {
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark--focused,
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--light--error--focused,
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--dark--error--focused {
   overflow-y: auto;
   height: 100%;
   max-height: 110px;
@@ -67,47 +81,57 @@
 
 .tagsinput--styled-avocode-email-tagsinput--dark,
 .tagsinput--styled-avocode-email-tagsinput--light,
+.tagsinput--styled-avocode-email-tagsinput--error,
 .collapsible-tagsinput--styled-avocode-email-tagsinput--light,
-.collapsible-tagsinput--styled-avocode-email-tagsinput--dark {
+.collapsible-tagsinput--styled-avocode-email-tagsinput--dark,
+.collapsible-tagsinput--styled-avocode-email-tagsinput--error {
   height: unset;
 }
 
 .avocode-email-tagsinput--styled-avocode-email-tagsinput--dark,
-.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark {
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark,
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--error {
   background-color: var(--input-background-color);
 }
 
 .tag__container--styled-avocode-email-tagsinput--light--error,
-.tag__container--styled-avocode-email-tagsinput--dark--error {
+.tag__container--styled-avocode-email-tagsinput--dark--error,
+.tag__container--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--light--error--error,
+.tag__container--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--dark--error--error {
   box-shadow: 0 0 0 1px var(--error-color);
   border: none;
   border-radius: 3px;
 }
 
 .tag--styled-avocode-email-tagsinput--light,
-.tag--styled-avocode-email-tagsinput--dark {
+.tag--styled-avocode-email-tagsinput--dark,
+.tag--styled-avocode-email-tagsinput--error {
   border-radius: 3px;
   color: #282828;
   border: none;
   cursor: pointer;
 }
 
-.tag--styled-avocode-email-tagsinput--light {
+.tag--styled-avocode-email-tagsinput--light,
+.tag--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--light--error {
   background-color: #f0f0f0;
 }
 
-.tag--styled-avocode-email-tagsinput--dark {
+.tag--styled-avocode-email-tagsinput--dark,
+.tag--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--dark--error {
   background-color: #585858;
 }
 
 .tag--styled-avocode-email-tagsinput--light--focused,
-.tag--styled-avocode-email-tagsinput--dark--focused {
+.tag--styled-avocode-email-tagsinput--dark--focused,
+.tag--styled-avocode-email-tagsinput--error.tag--focused {
   border-radius: 3px;
   box-shadow: 0 0 0 1px var(--brand-color);
 }
 
 .tag__label--styled-avocode-email-tagsinput--light,
-.tag__label--styled-avocode-email-tagsinput--dark {
+.tag__label--styled-avocode-email-tagsinput--dark,
+.tag__label--styled-avocode-email-tagsinput--error {
   font-size: var(--text-size);
   font-weight: 600;
   background-color: #f0f0f0;
@@ -115,18 +139,21 @@
   user-select: none;
 }
 
-.tag__label--styled-avocode-email-tagsinput--dark {
+.tag__label--styled-avocode-email-tagsinput--dark,
+.tag__label--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--dark--error {
   background-color: #585858;
   color: #fff;
 }
 
 .tag__remove-button--styled-avocode-email-tagsinput--light,
-.tag__remove-button--styled-avocode-email-tagsinput--dark {
+.tag__remove-button--styled-avocode-email-tagsinput--dark,
+.tag__remove-button--styled-avocode-email-tagsinput--error {
   margin-right: 5px;
 }
 
 .tag__remove-button--styled-avocode-email-tagsinput--light::before,
-.tag__remove-button--styled-avocode-email-tagsinput--dark::before {
+.tag__remove-button--styled-avocode-email-tagsinput--dark::before,
+.tag__remove-button--styled-avocode-email-tagsinput--error::before {
   position: absolute;
   opacity: 0.3;
   content: "\D7";
@@ -135,7 +162,8 @@
 }
 
 .tag__remove-button--styled-avocode-email-tagsinput--light:hover,
-.tag__remove-button--styled-avocode-email-tagsinput--dark:hover {
+.tag__remove-button--styled-avocode-email-tagsinput--dark:hover,
+.tag__remove-button--styled-avocode-email-tagsinput--error::hover {
   color: #fff;
 }
 
@@ -148,39 +176,52 @@
 }
 
 .avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--light,
-.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--dark {
+.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--dark,
+.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--error {
   margin: 0 4px 4px 0;
 }
 
-.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--dark {
+.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--dark,
+.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--dark--error {
   background-color: #585858;
   color: #fff;
 }
 
-.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--dark:hover {
+.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--dark:hover,
+.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--dark--error:hover {
   border-color: var(--brand-color);
 }
 
 .avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--light,
-.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--dark {
+.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--dark,
+.avocode-email-tagsinput-counter--styled-avocode-email-tagsinput--error {
   min-width: var(--counter-min-width);
 }
 
 /* HACK: Unfortunately the node where you type emails (query)
  *       does not have it's own CSS class */
-.tagsinput > div > div > span:only-child, .tagsinput > div > div > span:last-child {
+.tagsinput--styled-avocode-email-tagsinput--light > div > div > span:only-child,
+.tagsinput--styled-avocode-email-tagsinput--light > div > div > span:last-child,
+.tagsinput--styled-avocode-email-tagsinput--dark > div > div > span:only-child,
+.tagsinput--styled-avocode-email-tagsinput--dark > div > div > span:last-child,
+.tagsinput--styled-avocode-email-tagsinput--error > div > div > span:only-child,
+.tagsinput--styled-avocode-email-tagsinput--error > div > div > span:last-child {
   font-size: var(--text-size);
   margin: 4px 3px;
 }
 
 /* HACK: Firefox has issues with line-height */
 @-moz-document url-prefix() {
-  .tagsinput > div > div > span:last-child {
+  .tagsinput--styled-avocode-email-tagsinput--light > div > div > span:last-child,
+  .tagsinput--styled-avocode-email-tagsinput--dark > div > div > span:last-child,
+  .tagsinput--styled-avocode-email-tagsinput--error > div > div > span:last-child {
     margin: 5px;
     padding: 5px;
   }
 
-  .tagsinput > div > div > span:only-child {
+  .tagsinput--styled-avocode-email-tagsinput--light > div > div > span:only-child,
+  .tagsinput--styled-avocode-email-tagsinput--dark > div > div > span:only-child,
+  .tagsinput--styled-avocode-email-tagsinput--error > div > div > span:only-child {
     margin: 4px;
     padding: 5px;
   }

--- a/packages/styled-avocode-email-tagsinput/styles/styled-avocode-email-tagsinput.css
+++ b/packages/styled-avocode-email-tagsinput/styles/styled-avocode-email-tagsinput.css
@@ -26,6 +26,11 @@
   width: calc(100% - var(--counter-min-width));
 }
 
+.tagsinput--styled-avocode-email-tagsinput--light,
+.tagsinput--styled-avocode-email-tagsinput--dark {
+  font-size: var(--text-size);
+}
+
 .collapsible-tagsinput--styled-avocode-email-tagsinput--light--collapsed .tagsinput--styled-avocode-email-tagsinput--light,
 .collapsible-tagsinput--styled-avocode-email-tagsinput--dark--collapsed .tagsinput--styled-avocode-email-tagsinput--dark {
   border-width: 0;
@@ -33,7 +38,7 @@
 
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--light,
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark {
-  font-size: var(--text-size-1);
+  font-size: var(--text-size);
   height: 35px;
   overflow: hidden;
   align-items: flex-end;
@@ -103,7 +108,7 @@
 
 .tag__label--styled-avocode-email-tagsinput--light,
 .tag__label--styled-avocode-email-tagsinput--dark {
-  font-size: var(--text-size-1);
+  font-size: var(--text-size);
   font-weight: 600;
   background-color: #f0f0f0;
   cursor: pointer;

--- a/packages/styled-avocode-email-tagsinput/styles/variables-dark.css
+++ b/packages/styled-avocode-email-tagsinput/styles/variables-dark.css
@@ -1,5 +1,7 @@
 .avocode-email-tagsinput--styled-avocode-email-tagsinput--dark,
-.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark {
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark,
+.avocode-email-tagsinput--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--dark--error,
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--dark--error {
   --text-color-contrast: #fff;
   --input-border-color: transparent;
   --input-background-color: #171717;

--- a/packages/styled-avocode-email-tagsinput/styles/variables-light.css
+++ b/packages/styled-avocode-email-tagsinput/styles/variables-light.css
@@ -1,5 +1,7 @@
 .avocode-email-tagsinput--styled-avocode-email-tagsinput--light,
-.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--light {
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--light,
+.avocode-email-tagsinput--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--light--error,
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--error.styled-avocode-email-tagsinput--light--error {
   --text-color-contrast: #2e2e2e;
   --input-border-color: #dadada;
   --input-background-color: #fff;

--- a/packages/styled-avocode-email-tagsinput/styles/variables.css
+++ b/packages/styled-avocode-email-tagsinput/styles/variables.css
@@ -4,7 +4,11 @@
 .avocode-email-tagsinput--styled-avocode-email-tagsinput--light,
 .avocode-email-tagsinput--styled-avocode-email-tagsinput--dark,
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--light,
-.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark {
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark,
+.avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--error,
+.avocode-email-tagsinput--styled-avocode-email-tagsinput--error,
+.styled-avocode-email-tagsinput--light--error,
+.styled-avocode-email-tagsinput--dark--error {
   --brand-color: #00bc87; /* NOTE: avocode-ui color `main-color-brand-highlight` */
   --error-color: #f83a35; /* NOTE: avocode-ui color `error-color-brand` */
 

--- a/packages/styled-avocode-email-tagsinput/styles/variables.css
+++ b/packages/styled-avocode-email-tagsinput/styles/variables.css
@@ -8,7 +8,7 @@
   --brand-color: #00bc87; /* NOTE: avocode-ui color `main-color-brand-highlight` */
   --error-color: #f83a35; /* NOTE: avocode-ui color `error-color-brand` */
 
-  --text-size-1: 1.1rem;
+  --text-size: 10px; /* NOTE: Opinionated size so input looks good */
 
   --counter-min-width: 25px;
 }


### PR DESCRIPTION
I made a mistake when developing the library via the playground. The `html` tag has a `font-size` for `10px` but all the CSS classes use relative `rem` units. I made this so it's flexible to construct your inputs with any font size.
The problem is that `@avocode/styled-avocode-email-tagsinput` is very opinionated about its styles. For this reason I had to set fixed font size so the whole UI looks uniform.

In the future, I might add support and adjust stylesheets so different font sizes are supported.

This PR fixes missing functionality for displaying `StyledAvocodeEmailTagsInput` in error state. I had to do some refactors to get desired effect.