### PR TITLE
Fix/add user select fix for safari

### DIFF
--- a/packages/playground/components/styled-avocode-email-tagsinput/controlled.js
+++ b/packages/playground/components/styled-avocode-email-tagsinput/controlled.js
@@ -34,6 +34,17 @@ export default class Controlled extends React.PureComponent<{}, State> {
     })
   }
 
+  _handleRandomTagAdded = () => {
+    const text = `${Date.now().toString().substring(8)}@avcd.cz`
+
+    this.setState((prevState) => {
+      return {
+        tags: [ ...prevState.tags, { value: text } ],
+        query: '',
+      }
+    })
+  }
+
   _handleQueryChange = (query: Query) => {
     this.setState({ query })
   }
@@ -56,6 +67,7 @@ export default class Controlled extends React.PureComponent<{}, State> {
     return (
       <div>
         <StateView tags={this.state.tags} query={this.state.query} />
+        <button onClick={this._handleRandomTagAdded}>Add random email</button>
 
         <div className='theme-container theme-container--light'>
           <StyledAvocodeEmailTagsInput

--- a/packages/styled-avocode-email-tagsinput/styles/styled-avocode-email-tagsinput.css
+++ b/packages/styled-avocode-email-tagsinput/styles/styled-avocode-email-tagsinput.css
@@ -12,6 +12,16 @@
   font-weight: 600;
 }
 
+/* NOTE: Override `avocode-ui/reset.less`. This needs to be
+         done so the editor works correctly in Safari */
+.tagsinput--styled-avocode-email-tagsinput--light *,
+.tagsinput--styled-avocode-email-tagsinput--dark *,
+.tagsinput--styled-avocode-email-tagsinput--error * {
+  user-select: auto;
+  -webkit-user-select: auto;
+  -moz-user-select: auto;
+}
+
 .tagsinput--styled-avocode-email-tagsinput--dark,
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark {
   border-color: transparent;

--- a/packages/styled-avocode-email-tagsinput/styles/styled-avocode-email-tagsinput.css
+++ b/packages/styled-avocode-email-tagsinput/styles/styled-avocode-email-tagsinput.css
@@ -61,7 +61,8 @@
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--dark,
 .avocode-email-tagsinput-collapsible--styled-avocode-email-tagsinput--error {
   font-size: var(--text-size);
-  height: 35px;
+  height: var(--input-height);
+  max-height: var(--input-height);
   overflow: hidden;
   align-items: flex-end;
   justify-content: space-between;
@@ -218,21 +219,43 @@
 .tagsinput--styled-avocode-email-tagsinput--error > div > div > span:last-child {
   font-size: var(--text-size);
   margin: 4px 3px;
+  line-height: 1.3;
+}
+
+.collapsible-tagsinput--styled-avocode-email-tagsinput--light .tagsinput--styled-avocode-email-tagsinput--light--focused > div > div > span:only-child,
+.collapsible-tagsinput--styled-avocode-email-tagsinput--light .tagsinput--styled-avocode-email-tagsinput--light--focused > div > div > span:last-child,
+.collapsible-tagsinput--styled-avocode-email-tagsinput--dark .tagsinput--styled-avocode-email-tagsinput--dark--focused > div > div > span:only-child,
+.collapsible-tagsinput--styled-avocode-email-tagsinput--dark .tagsinput--styled-avocode-email-tagsinput--dark--focused > div > div > span:last-child,
+.collapsible-tagsinput--styled-avocode-email-tagsinput--dark--error .tagsinput--styled-avocode-email-tagsinput--dark--error--focused > div > div > span:only-child,
+.collapsible-tagsinput--styled-avocode-email-tagsinput--dark--error .tagsinput--styled-avocode-email-tagsinput--dark--error--focused > div > div > span:last-child {
+  font-size: var(--text-size);
+  margin: 4px 3px;
+  line-height: 1.5;
 }
 
 /* HACK: Firefox has issues with line-height */
 @-moz-document url-prefix() {
   .tagsinput--styled-avocode-email-tagsinput--light > div > div > span:last-child,
   .tagsinput--styled-avocode-email-tagsinput--dark > div > div > span:last-child,
-  .tagsinput--styled-avocode-email-tagsinput--error > div > div > span:last-child {
-    margin: 5px;
-    padding: 5px;
+  .tagsinput--styled-avocode-email-tagsinput--error > div > div > span:last-child,
+  .collapsible-tagsinput--styled-avocode-email-tagsinput--light .tagsinput--styled-avocode-email-tagsinput--light--focused > div > div > span:last-child,
+  .collapsible-tagsinput--styled-avocode-email-tagsinput--dark .tagsinput--styled-avocode-email-tagsinput--dark--focused > div > div > span:last-child,
+  .collapsible-tagsinput--styled-avocode-email-tagsinput--dark--error .tagsinput--styled-avocode-email-tagsinput--dark--error--focused > div > div > span:last-child {
+    font-size: var(--text-size);
+    margin: 4px 3px;
+    padding: 4px;
+    line-height: 0.75;
   }
 
   .tagsinput--styled-avocode-email-tagsinput--light > div > div > span:only-child,
   .tagsinput--styled-avocode-email-tagsinput--dark > div > div > span:only-child,
-  .tagsinput--styled-avocode-email-tagsinput--error > div > div > span:only-child {
-    margin: 4px;
-    padding: 5px;
+  .tagsinput--styled-avocode-email-tagsinput--error > div > div > span:only-child,
+  .collapsible-tagsinput--styled-avocode-email-tagsinput--light .tagsinput--styled-avocode-email-tagsinput--light--focused > div > div > span:only-child,
+  .collapsible-tagsinput--styled-avocode-email-tagsinput--dark .tagsinput--styled-avocode-email-tagsinput--dark--focused > div > div > span:only-child,
+  .collapsible-tagsinput--styled-avocode-email-tagsinput--dark--error .tagsinput--styled-avocode-email-tagsinput--dark--error--focused > div > div > span:only-child {
+    font-size: var(--text-size);
+    margin: 4px 3px;
+    padding: 4px;
+    line-height: 1.15;
   }
 }

--- a/packages/styled-avocode-email-tagsinput/styles/variables.css
+++ b/packages/styled-avocode-email-tagsinput/styles/variables.css
@@ -9,6 +9,7 @@
 .avocode-email-tagsinput--styled-avocode-email-tagsinput--error,
 .styled-avocode-email-tagsinput--light--error,
 .styled-avocode-email-tagsinput--dark--error {
+  --input-height: 35px;
   --brand-color: #00bc87; /* NOTE: avocode-ui color `main-color-brand-highlight` */
   --error-color: #f83a35; /* NOTE: avocode-ui color `error-color-brand` */
 


### PR DESCRIPTION
This should fix problems in Safari when `user-select: none` property is set on parent components. Users should rely on `disabled` or `readOnly` prop instead of modifying behaviour via CSS.